### PR TITLE
Update .dockstore.yml

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -2,4 +2,4 @@ version: 1.2
 workflows:
     - name: fetch_dbgap_files_wdl
       subclass: WDL
-      primaryDescriptorPath: fetch_dbgap_files.wdl
+      primaryDescriptorPath: /fetch_dbgap_files.wdl


### PR DESCRIPTION
We also know that relative paths have caused problems in the past and will be migrating to validating absolute paths only as in the examples at https://docs.dockstore.org/en/stable/assets/templates/workflows/workflows.html