### PR TITLE
Allow the user to specify the number of files instead of the manifest

### DIFF
--- a/fetch_dbgap_files.wdl
+++ b/fetch_dbgap_files.wdl
@@ -3,9 +3,10 @@ version 1.0
 workflow fetch_dbgap_files {
     input {
         File cart_file
-        File manifest_file
         File ngc_file
         String output_directory
+        File? manifest_file
+        Int? n_files
         Int? disk_gb
     }
 
@@ -13,6 +14,7 @@ workflow fetch_dbgap_files {
         input:
             cart_file=cart_file,
             manifest_file=manifest_file,
+            n_files=n_files,
             ngc_file=ngc_file,
             output_directory=output_directory,
             disk_gb=disk_gb
@@ -29,24 +31,26 @@ workflow fetch_dbgap_files {
 task fetch_files {
     input {
         File cart_file
-        File manifest_file
         File ngc_file
         String output_directory
         Int disk_gb = 50
+        File? manifest_file
+        Int? n_files
     }
     command {
         python3 /usr/local/fetch-dbgap-files/fetch.py \
             --prefetch /opt/sratoolkit.3.0.10-ubuntu64/bin/prefetch \
             --ngc ~{ngc_file} \
             --cart ~{cart_file} \
-            --manifest ~{manifest_file} \
+            ~{"--manifest " + manifest_file} \
+            ~{"--n-files " + n_files} \
             --outdir tmp_download \
             --untar
         gsutil -m cp -r tmp_download/* ~{output_directory}
     }
     runtime {
         # Pull from DockerHub
-        docker: "uwgac/fetch-dbgap-files:0.1.0"
+        docker: "uwgac/fetch-dbgap-files:0.2.0"
         disks: "local-disk ${disk_gb} SSD"
     }
 }


### PR DESCRIPTION
It is proving difficult to consistently get the correct set of files to download from dbGaP File Selector. Instead of requiring a manifest, allow the user to specify the number of expected files. The code then checks if the number of files in the directory matches the number of expected files, and if not, retries the download.