### PR TITLE
Use the cart file to get file manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.18.0
 
-ENV SRATOOLKIT_VERSION="3.0.10"
+ENV SRATOOLKIT_VERSION="3.2.1"
 
 # Check out repository files.
 RUN cd /usr/local && \

--- a/fetch.py
+++ b/fetch.py
@@ -24,9 +24,7 @@ class dbGaPFileFetcher:
         self.prefetch = os.path.abspath(prefetch)
         self.output_dir = os.path.abspath(output_dir)
 
-    def download_files(
-        self, cart, manifest=None, n_files=None, n_retries=3, untar=False
-    ):
+    def download_files(self, cart, n_retries=3, untar=False):
         """Download files from dbGaP using a kart file. Because prefetch sometimes fails to download a file
         but does not report an error, this method will retry downloading the cart a number of times.
 
@@ -40,8 +38,10 @@ class dbGaPFileFetcher:
             n_files (int): The number of files that should be downloaded. If this is provided, the method will
                            check that this many files were downloaded.
         """
-        # Work in a temporary directory to do the downloading.
         cart_file = os.path.abspath(cart)
+        # Get the manifest from the cart file.
+        manifest = self._read_manifest_from_cart(cart_file)
+        # Work in a temporary directory to do the downloading.
         original_working_directory = os.getcwd()
         with tempfile.TemporaryDirectory() as temp_dir:
             os.chdir(temp_dir)
@@ -54,17 +54,9 @@ class dbGaPFileFetcher:
                 if i == n_retries:
                     print("Failed to download all files.")
                     return False
-                if manifest:
-                    all_files_downloaded = self._check_prefetch_against_manifest(
-                        temp_dir, manifest
-                    )
-                elif n_files:
-                    all_files_downloaded = self._check_prefetch_against_n_files(
-                        temp_dir, n_files
-                    )
-                else:
-                    # If no manifest or n_files was provided, we have to assume that it worked.
-                    all_files_downloaded = True
+                all_files_downloaded = self._check_prefetch_against_manifest(
+                    temp_dir, manifest
+                )
                 i = i + 1
             if untar:
                 self._untar(temp_dir)
@@ -93,15 +85,6 @@ class dbGaPFileFetcher:
 
         return manifest
 
-    def _read_manifest(self, manifest):
-        """Read the manifest file."""
-        files = []
-        with open(manifest) as f:
-            cf = csv.DictReader(f)
-            for row in cf:
-                files.append(row["File Name"])
-        return files
-
     def _run_prefetch(self, cart_file):
         """Run the prefetch command to download files from dbGaP."""
         cmd = (
@@ -124,7 +107,7 @@ class dbGaPFileFetcher:
 
     def _check_prefetch_against_manifest(self, directory, manifest):
         """Check that prefetch downloaded all the files in the manifest."""
-        expected_files = self._read_manifest(manifest)
+        expected_files = manifest
         downloaded_files = os.listdir(directory)
         print("Found downloaded files:")
         print(sorted(downloaded_files))
@@ -134,14 +117,6 @@ class dbGaPFileFetcher:
             len(downloaded_files),
         )
         return set(downloaded_files) == set(expected_files)
-
-    def _check_prefetch_against_n_files(self, directory, n_files):
-        """Check that prefetch downloaded the expected number of files."""
-        downloaded_files = os.listdir(directory)
-        print("Found downloaded files:")
-        print(sorted(downloaded_files))
-        print("Expected {} files; found {} files.", n_files, len(downloaded_files))
-        return len(downloaded_files) == n_files
 
     def _untar(self, directory):
         """Untar all tar files in the directory."""
@@ -178,12 +153,6 @@ if __name__ == "__main__":
     parser.add_argument("--cart", help="The cart file to use.", required=True)
     parser.add_argument(
         "--outdir", help="The directory where files should be saved.", required=True
-    )
-    # Files for downloading.
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--manifest", help="The manifest file to use.", type=str)
-    group.add_argument(
-        "--n-files", help="The number of files expected to download.", type=int
     )
     # Optional arguments.
     parser.add_argument(

--- a/fetch.py
+++ b/fetch.py
@@ -24,7 +24,9 @@ class dbGaPFileFetcher:
         self.prefetch = os.path.abspath(prefetch)
         self.output_dir = os.path.abspath(output_dir)
 
-    def download_files(self, cart, manifest=None, n_files=None, n_retries=3, untar=False):
+    def download_files(
+        self, cart, manifest=None, n_files=None, n_retries=3, untar=False
+    ):
         """Download files from dbGaP using a kart file. Because prefetch sometimes fails to download a file
         but does not report an error, this method will retry downloading the cart a number of times.
 
@@ -53,9 +55,13 @@ class dbGaPFileFetcher:
                     print("Failed to download all files.")
                     return False
                 if manifest:
-                    all_files_downloaded = self._check_prefetch_against_manifest(temp_dir, manifest)
+                    all_files_downloaded = self._check_prefetch_against_manifest(
+                        temp_dir, manifest
+                    )
                 elif n_files:
-                    all_files_downloaded = self._check_prefetch_against_n_files(temp_dir, n_files)
+                    all_files_downloaded = self._check_prefetch_against_n_files(
+                        temp_dir, n_files
+                    )
                 else:
                     # If no manifest or n_files was provided, we have to assume that it worked.
                     all_files_downloaded = True
@@ -64,7 +70,9 @@ class dbGaPFileFetcher:
                 self._untar(temp_dir)
             # Copy files to the output directory
             os.chdir(original_working_directory)
-            shutil.copytree(temp_dir, self.output_dir, copy_function=shutil.move, dirs_exist_ok=True)
+            shutil.copytree(
+                temp_dir, self.output_dir, copy_function=shutil.move, dirs_exist_ok=True
+            )
             return True
 
     def _read_manifest(self, manifest):
@@ -102,7 +110,11 @@ class dbGaPFileFetcher:
         downloaded_files = os.listdir(directory)
         print("Found downloaded files:")
         print(sorted(downloaded_files))
-        print("Expected {} files; found {} files.", len(expected_files), len(downloaded_files))
+        print(
+            "Expected {} files; found {} files.",
+            len(expected_files),
+            len(downloaded_files),
+        )
         return set(downloaded_files) == set(expected_files)
 
     def _check_prefetch_against_n_files(self, directory, n_files):
@@ -116,7 +128,11 @@ class dbGaPFileFetcher:
     def _untar(self, directory):
         """Untar all tar files in the directory."""
         print("Untarring files.")
-        tar_files = [f for f in os.listdir(directory) if f.endswith(".tar") or f.endswith(".tar.gz")]
+        tar_files = [
+            f
+            for f in os.listdir(directory)
+            if f.endswith(".tar") or f.endswith(".tar.gz")
+        ]
         for f in tar_files:
             extract_directory = os.path.join(directory, f.split(".tar")[0])
             os.mkdir(os.path.join(extract_directory))
@@ -129,23 +145,40 @@ class dbGaPFileFetcher:
             # Remove the tar archive.
             os.remove(os.path.join(directory, f))
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Fetches files from dbGaP using a kart file.",
         prog="fetch",
     )
     # Required arguments.
-    parser.add_argument("--ngc", help="The path to the ngc file containing the project key.", required=True)
+    parser.add_argument(
+        "--ngc",
+        help="The path to the ngc file containing the project key.",
+        required=True,
+    )
     parser.add_argument("--cart", help="The cart file to use.", required=True)
-    parser.add_argument("--outdir", help="The directory where files should be saved.", required=True)
+    parser.add_argument(
+        "--outdir", help="The directory where files should be saved.", required=True
+    )
     # Files for downloading.
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--manifest", help="The manifest file to use.", type=str)
-    group.add_argument("--n-files", help="The number of files expected to download.", type=int)
+    group.add_argument(
+        "--n-files", help="The number of files expected to download.", type=int
+    )
     # Optional arguments.
-    parser.add_argument("--prefetch", help="The path to the prefetch executable.", default="prefetch")
-    parser.add_argument("--verbose", help="Print more information.", action="store_true")
-    parser.add_argument("--untar", help="Untar any tar archives into a directory with the same basename as the archive.", action="store_true")
+    parser.add_argument(
+        "--prefetch", help="The path to the prefetch executable.", default="prefetch"
+    )
+    parser.add_argument(
+        "--verbose", help="Print more information.", action="store_true"
+    )
+    parser.add_argument(
+        "--untar",
+        help="Untar any tar archives into a directory with the same basename as the archive.",
+        action="store_true",
+    )
 
     # Parse.
     args = parser.parse_args()
@@ -153,7 +186,9 @@ if __name__ == "__main__":
     # Set up the class.
     fetcher = dbGaPFileFetcher(args.ngc, args.prefetch, args.outdir)
     # Download.
-    files_downloaded = fetcher.download_files(args.cart, manifest=args.manifest, n_files=args.n_files, untar=args.untar)
+    files_downloaded = fetcher.download_files(
+        args.cart, manifest=args.manifest, n_files=args.n_files, untar=args.untar
+    )
     if not files_downloaded:
         sys.exit(1)
     else:

--- a/fetch.py
+++ b/fetch.py
@@ -173,9 +173,7 @@ if __name__ == "__main__":
     # Set up the class.
     fetcher = dbGaPFileFetcher(args.ngc, args.prefetch, args.outdir)
     # Download.
-    files_downloaded = fetcher.download_files(
-        args.cart, manifest=args.manifest, n_files=args.n_files, untar=args.untar
-    )
+    files_downloaded = fetcher.download_files(args.cart, untar=args.untar)
     if not files_downloaded:
         sys.exit(1)
     else:

--- a/fetch.py
+++ b/fetch.py
@@ -75,6 +75,24 @@ class dbGaPFileFetcher:
             )
             return True
 
+    def _read_manifest_from_cart(self, cart_file):
+        """Run the prefetch command to get the list of files from the cart file."""
+        cmd = ("{prefetch} --cart {cart} --list > tmp.txt").format(
+            prefetch=self.prefetch,
+            cart=cart_file,
+        )
+
+        subprocess.call(cmd, shell=True)
+
+        with open("tmp.txt") as f:
+            out = f.readlines()
+        # Remove the first and last lines - these are headers and footers.
+        out = out[1 : (len(out) - 1)]
+        # Split on | and get the 4th element
+        manifest = [x.split("|")[3].strip() for x in out]
+
+        return manifest
+
     def _read_manifest(self, manifest):
         """Read the manifest file."""
         files = []

--- a/fetch_dbgap_files.wdl
+++ b/fetch_dbgap_files.wdl
@@ -5,16 +5,12 @@ workflow fetch_dbgap_files {
         File cart_file
         File ngc_file
         String output_directory
-        File? manifest_file
-        Int? n_files
         Int? disk_gb
     }
 
     call fetch_files {
         input:
             cart_file=cart_file,
-            manifest_file=manifest_file,
-            n_files=n_files,
             ngc_file=ngc_file,
             output_directory=output_directory,
             disk_gb=disk_gb
@@ -39,18 +35,16 @@ task fetch_files {
     }
     command {
         python3 /usr/local/fetch-dbgap-files/fetch.py \
-            --prefetch /opt/sratoolkit.3.0.10-ubuntu64/bin/prefetch \
+            --prefetch /opt/sratoolkit.3.2.1-ubuntu64/bin/prefetch \
             --ngc ~{ngc_file} \
             --cart ~{cart_file} \
-            ~{"--manifest " + manifest_file} \
-            ~{"--n-files " + n_files} \
             --outdir tmp_download \
             --untar
         gsutil -m cp -r tmp_download/* ~{output_directory}
     }
     runtime {
         # Pull from DockerHub
-        docker: "uwgac/fetch-dbgap-files:0.2.1"
+        docker: "uwgac/fetch-dbgap-files:0.3.0"
         disks: "local-disk ${disk_gb} SSD"
     }
 }

--- a/fetch_dbgap_files.wdl
+++ b/fetch_dbgap_files.wdl
@@ -30,8 +30,6 @@ task fetch_files {
         File ngc_file
         String output_directory
         Int disk_gb = 50
-        File? manifest_file
-        Int? n_files
     }
     command {
         python3 /usr/local/fetch-dbgap-files/fetch.py \

--- a/fetch_dbgap_files.wdl
+++ b/fetch_dbgap_files.wdl
@@ -32,6 +32,8 @@ task fetch_files {
         Int disk_gb = 50
     }
     command {
+        set -e -o pipefail
+
         python3 /usr/local/fetch-dbgap-files/fetch.py \
             --prefetch /opt/sratoolkit.3.2.1-ubuntu64/bin/prefetch \
             --ngc ~{ngc_file} \


### PR DESCRIPTION
- Use sratoolkit v3.2.1 (which restores the ability to list the requested files in a cart file, see  #969)
- Remove the manifest and n_files arguments from the WDL and python script
- Add a new method to the python class to read the manifest from the cart file
